### PR TITLE
Added support for 1.20 chest boats, fixed bugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>nu.nerd</groupId>
 	<name>VehicleControl</name>
 	<artifactId>${project.name}</artifactId>
-	<version>1.1.0</version>
+	<version>1.2.0</version>
 	<packaging>jar</packaging>
 	<description>Automatically break boats and minecarts.</description>
 	<url>https://github.com/NerdNu/${project.name}</url>
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18.1-R0.1-SNAPSHOT</version>
+			<version>1.20-R0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/nu/nerd/vc/VehicleMetadata.java
+++ b/src/nu/nerd/vc/VehicleMetadata.java
@@ -65,7 +65,6 @@ public class VehicleMetadata extends MetadataValueAdapter {
      */
     public boolean isOccupied() {
         return _occupied;
-
     }
 
     // --------------------------------------------------------------------


### PR DESCRIPTION
Added support for the new chest boats, cause of plugin halting moments after the server started.
- Chest boats will not break if they have items in them
- Chest boats will drop a boat and chest upon removal

Fixed boat types not being properly chosen, resulting in any boat becoming acacia.
